### PR TITLE
Add bounded formal verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 
 # Selecto Library Changelog
 
+## V 0.4.8 - Bounded Formal Verification
+---------------------------------------------------------
+
+#### Security
+- Added bounded-exhaustive verification for required query scope and fixed a
+  fail-open path where an attached tenant id could satisfy validation before it
+  had been applied as a required SQL filter.
+
+#### Changed
+- Added `mix selecto.verify`, JSON proof artifacts, a reusable bounded model
+  checker, and exhaustive provider/consumer compatibility verification.
+- Added package documentation for the exact bounded proof guarantees and
+  remaining relational-equivalence boundary.
+- Bump package version to `0.4.8`.
+
 ## V 0.4.7 - Runtime Safety and Execution Reliability
 ---------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > Alpha software. Expect API churn and breaking changes while the core package is still being hardened.
 
+Selecto includes bounded formal-verification suites for tenant query scope and
+provider/consumer domain compatibility. Run `mix selecto.verify`; see
+[`docs/formal_verification.md`](docs/formal_verification.md) for the exact proof
+boundary and JSON artifact support.
+
 `selecto` is the core query engine in the Selecto ecosystem.
 
 It gives you:

--- a/docs/formal_verification.md
+++ b/docs/formal_verification.md
@@ -1,0 +1,77 @@
+# Selecto Formal Verification
+
+Selecto ships a deterministic bounded model checker and two built-in proof
+suites. They provide stronger evidence than sampled tests: every invariant is
+checked against every state in an explicitly defined finite model.
+
+Run the suites with:
+
+```sh
+mise exec -- mix selecto.verify
+mise exec -- mix selecto.verify --output tmp/selecto-verification.json
+```
+
+The command exits non-zero when it finds a counterexample. The optional JSON
+artifact records the proof level, model identity, state count, invariant count,
+check count, and any reproducible counterexamples.
+
+## Current Proofs
+
+### Query scope
+
+`selecto.query_scope.v1` exhaustively crosses:
+
+- tenant-required and tenant-optional domains;
+- absent, row-tenant, and schema-prefix contexts;
+- applied and unapplied row scope;
+- absent and present ordinary user filters.
+
+For all 24 states it proves:
+
+- required scope fails closed;
+- required filters survive query composition;
+- row-tenant values reach SQL through parameters rather than interpolation;
+- ordinary user filters cannot substitute for required tenant scope.
+
+This model exposed and fixed a real fail-open condition: a tenant id attached as
+context was previously accepted as sufficient scope before it had been applied
+as a required query filter.
+
+### Provider/consumer contracts
+
+`selecto.domain_contract_compatibility.v1` exhaustively crosses compatible and
+incompatible field, filter, required-scope, version, and fingerprint
+dependencies.
+
+For all 32 states it proves:
+
+- only a fully compatible consumer is accepted;
+- every incompatible dimension is rejected;
+- each rejection includes its specific contract diagnostic.
+
+This complements stable contract snapshots and breaking-change classification
+in `Selecto.Domain.ContractVerification`.
+
+## Proof Meaning
+
+Reports use `proof_level: bounded_exhaustive`. A passing report means there is
+no counterexample in the complete, versioned finite model. It does not claim an
+unbounded theorem about every possible domain, custom SQL fragment, adapter, or
+database.
+
+The checker is intentionally in normal package code:
+
+```elixir
+Selecto.Verification.BoundedModel.check("my.model.v1", states, invariants)
+```
+
+Applications can therefore add finite models for their own tenant modes,
+published contracts, domain compositions, and policy rules.
+
+## Remaining Boundary
+
+These suites do not yet prove full relational equivalence between arbitrary
+Selecto intent and generated SQL. That requires an independent relational
+interpreter with explicit SQL `NULL`, bag, join, grouping, and ordering
+semantics, followed by bounded comparison against PostgreSQL. Until that layer
+exists, the existing SQL tests and live database suites remain necessary.

--- a/lib/mix/tasks/selecto.verify.ex
+++ b/lib/mix/tasks/selecto.verify.ex
@@ -1,0 +1,72 @@
+defmodule Mix.Tasks.Selecto.Verify do
+  use Mix.Task
+
+  @shortdoc "Runs Selecto bounded formal-verification suites"
+
+  @moduledoc """
+  Runs the Selecto bounded formal-verification suites.
+
+      mix selecto.verify
+      mix selecto.verify --output tmp/selecto-verification.json
+
+  Exit status is non-zero if any suite produces a counterexample. Reports state
+  the proof level and finite model size so bounded results cannot be confused
+  with unbounded theorem proving.
+  """
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, rest, invalid} = OptionParser.parse(args, strict: [output: :string])
+
+    if rest != [] or invalid != [] do
+      Mix.raise("usage: mix selecto.verify [--output PATH]")
+    end
+
+    reports = [
+      Selecto.Verification.QuerySafety.verify(),
+      Selecto.Verification.ContractSafety.verify()
+    ]
+
+    artifact = artifact(reports)
+
+    Enum.each(reports, &print_report/1)
+    maybe_write(artifact, opts[:output])
+
+    unless artifact.proved? do
+      Mix.raise("Selecto formal verification found counterexamples")
+    end
+  end
+
+  defp artifact(reports) do
+    %{
+      format: "selecto.formal_verification_suite",
+      format_version: 1,
+      generated_at: DateTime.utc_now() |> DateTime.to_iso8601(),
+      proved?: Enum.all?(reports, & &1.proved?),
+      reports: reports
+    }
+  end
+
+  defp print_report(report) do
+    status = if report.proved?, do: "PROVED", else: "FAILED"
+
+    Mix.shell().info(
+      "#{status} #{report.model}: #{report.check_count} checks " <>
+        "(#{report.state_count} states x #{report.invariant_count} invariants, " <>
+        "proof=#{report.proof_level})"
+    )
+
+    Enum.each(report.counterexamples, fn counterexample ->
+      Mix.shell().error("counterexample: #{inspect(counterexample, pretty: true)}")
+    end)
+  end
+
+  defp maybe_write(_artifact, nil), do: :ok
+
+  defp maybe_write(artifact, path) do
+    path = Path.expand(path)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, Jason.encode_to_iodata!(artifact, pretty: true))
+    Mix.shell().info("Wrote verification artifact to #{path}")
+  end
+end

--- a/lib/selecto/tenant.ex
+++ b/lib/selecto/tenant.ex
@@ -262,9 +262,10 @@ defmodule Selecto.Tenant do
     field = tenant_field(selecto, opts)
     required = required_filter_scope?(selecto, field)
     has_prefix = map_get(tenant_context, :prefix) |> present_string?()
-    has_id = not is_nil(map_get(tenant_context, :tenant_id))
-
-    required or has_prefix or has_id
+    # A context id is intent, not proof that row scope reached the query.
+    # `apply_tenant_scope/2` turns that id into a required filter. Accepting the
+    # id alone lets validation pass while generated SQL remains unscoped.
+    required or has_prefix
   end
 
   defp tenant_field(selecto, opts) do

--- a/lib/selecto/verification/bounded_model.ex
+++ b/lib/selecto/verification/bounded_model.ex
@@ -1,0 +1,141 @@
+defmodule Selecto.Verification.BoundedModel do
+  @moduledoc """
+  Deterministic, exhaustive checking over an explicitly bounded state space.
+
+  This is a small model-checking kernel used by Selecto's verification suites.
+  It is deliberately dependency-free so verification is available to package
+  consumers and Mix tasks, not only to the test environment.
+
+  A successful report proves that every invariant held for every supplied
+  state. The proof is bounded by the caller's finite model; the report records
+  the exact model size and never presents the result as an unbounded theorem.
+  """
+
+  @type invariant ::
+          {String.t() | atom(), (term() -> :ok | true | {:error, term()} | false)}
+
+  @type report :: %{
+          format: String.t(),
+          format_version: pos_integer(),
+          proof_level: :bounded_exhaustive,
+          model: String.t(),
+          state_count: non_neg_integer(),
+          invariant_count: non_neg_integer(),
+          check_count: non_neg_integer(),
+          proved?: boolean(),
+          counterexamples: [map()]
+        }
+
+  @doc """
+  Checks every invariant against every state and returns a stable proof report.
+
+  Invariants should return `:ok` or `true` when satisfied. `{:error, reason}`,
+  `false`, exceptions, and throws are captured as reproducible
+  counterexamples.
+  """
+  @spec check(String.t() | atom(), Enumerable.t(), [invariant()]) :: report()
+  def check(model, states, invariants) when is_list(invariants) do
+    states = Enum.to_list(states)
+
+    counterexamples =
+      for {state, state_index} <- Enum.with_index(states),
+          {invariant, invariant_index} <- Enum.with_index(invariants),
+          counterexample <-
+            check_invariant(state, state_index, invariant, invariant_index),
+          do: counterexample
+
+    %{
+      format: "selecto.formal_verification",
+      format_version: 1,
+      proof_level: :bounded_exhaustive,
+      model: to_string(model),
+      state_count: length(states),
+      invariant_count: length(invariants),
+      check_count: length(states) * length(invariants),
+      proved?: counterexamples == [],
+      counterexamples: counterexamples
+    }
+  end
+
+  defp check_invariant(state, state_index, {name, invariant}, invariant_index)
+       when is_function(invariant, 1) do
+    result =
+      try do
+        invariant.(state)
+      rescue
+        exception -> {:exception, exception.__struct__, Exception.message(exception)}
+      catch
+        kind, reason -> {:caught, kind, reason}
+      end
+
+    case result do
+      :ok ->
+        []
+
+      true ->
+        []
+
+      {:exception, _module, _message} = reason ->
+        [counterexample(state, state_index, name, invariant_index, reason)]
+
+      {:caught, _kind, _value} = reason ->
+        [counterexample(state, state_index, name, invariant_index, reason)]
+
+      {:error, reason} ->
+        [counterexample(state, state_index, name, invariant_index, reason)]
+
+      false ->
+        [counterexample(state, state_index, name, invariant_index, :returned_false)]
+
+      other ->
+        [
+          counterexample(
+            state,
+            state_index,
+            name,
+            invariant_index,
+            {:invalid_invariant_result, other}
+          )
+        ]
+    end
+  end
+
+  defp counterexample(state, state_index, name, invariant_index, reason) do
+    %{
+      invariant: to_string(name),
+      invariant_index: invariant_index,
+      state_index: state_index,
+      state: portable(state),
+      reason: portable(reason)
+    }
+  end
+
+  # Proof artifacts must remain serializable even when a model uses structs,
+  # tuples, functions, pids, or exceptions internally.
+  defp portable(value)
+       when is_nil(value) or is_boolean(value) or is_binary(value) or is_number(value) or
+              is_atom(value),
+       do: value
+
+  defp portable(value) when is_list(value), do: Enum.map(value, &portable/1)
+
+  defp portable(value) when is_tuple(value) do
+    %{tuple: value |> Tuple.to_list() |> Enum.map(&portable/1)}
+  end
+
+  defp portable(%module{} = value) do
+    value
+    |> Map.from_struct()
+    |> portable()
+    |> Map.put(:struct, inspect(module))
+  end
+
+  defp portable(value) when is_map(value) do
+    Map.new(value, fn {key, item} -> {portable_key(key), portable(item)} end)
+  end
+
+  defp portable(value), do: inspect(value)
+
+  defp portable_key(key) when is_atom(key) or is_binary(key), do: key
+  defp portable_key(key), do: inspect(key)
+end

--- a/lib/selecto/verification/contract_safety.ex
+++ b/lib/selecto/verification/contract_safety.ex
@@ -1,0 +1,166 @@
+defmodule Selecto.Verification.ContractSafety do
+  @moduledoc """
+  Bounded verification of provider/consumer contract compatibility.
+
+  The model exhaustively crosses valid and invalid field, filter, required
+  scope, version, and fingerprint dependencies. It proves that compatible
+  consumers are accepted and every incompatible dimension is rejected with
+  its specific diagnostic.
+  """
+
+  alias Selecto.Domain.ContractVerification
+  alias Selecto.Verification.BoundedModel
+
+  @doc """
+  Runs the built-in contract compatibility model.
+  """
+  @spec verify() :: BoundedModel.report()
+  def verify do
+    BoundedModel.check("selecto.domain_contract_compatibility.v1", states(), invariants())
+  end
+
+  defp states do
+    for field_valid? <- [false, true],
+        filter_valid? <- [false, true],
+        scope_satisfied? <- [false, true],
+        version_valid? <- [false, true],
+        fingerprint_valid? <- [false, true] do
+      dimensions = %{
+        field_valid?: field_valid?,
+        filter_valid?: filter_valid?,
+        scope_satisfied?: scope_satisfied?,
+        version_valid?: version_valid?,
+        fingerprint_valid?: fingerprint_valid?
+      }
+
+      consumer = consumer_domain(dimensions)
+
+      Map.put(
+        dimensions,
+        :verification,
+        ContractVerification.verify(provider_domain(), consumer)
+      )
+    end
+  end
+
+  defp invariants do
+    [
+      {"compatibility_result_is_complete", &compatibility_result_is_complete/1},
+      {"incompatible_dimensions_have_specific_diagnostics", &specific_diagnostics/1}
+    ]
+  end
+
+  defp compatibility_result_is_complete(state) do
+    expected_compatible? =
+      Enum.all?(
+        Map.take(state, [
+          :field_valid?,
+          :filter_valid?,
+          :scope_satisfied?,
+          :version_valid?,
+          :fingerprint_valid?
+        ]),
+        fn {_dimension, valid?} -> valid? end
+      )
+
+    actual_compatible? = match?({:ok, _report}, state.verification)
+
+    if actual_compatible? == expected_compatible?,
+      do: :ok,
+      else: {:error, %{expected_compatible?: expected_compatible?, result: state.verification}}
+  end
+
+  defp specific_diagnostics(%{verification: {:ok, _report}}), do: :ok
+
+  defp specific_diagnostics(%{verification: {:error, report}} = state) do
+    codes = MapSet.new(report.errors, &Map.fetch!(&1, :code))
+
+    expected_codes =
+      [
+        {not state.field_valid?, :missing_field},
+        {not state.filter_valid?, :missing_filter},
+        {not state.scope_satisfied?, :unsatisfied_required_filter},
+        {not state.version_valid?, :incompatible_contract_version},
+        {not state.fingerprint_valid?, :provider_fingerprint_changed}
+      ]
+      |> Enum.filter(fn {expected?, _code} -> expected? end)
+      |> Enum.map(fn {_expected?, code} -> code end)
+      |> MapSet.new()
+
+    missing = MapSet.difference(expected_codes, codes) |> MapSet.to_list()
+
+    if missing == [], do: :ok, else: {:error, %{missing_diagnostic_codes: missing}}
+  end
+
+  defp provider_domain do
+    base_domain()
+    |> update_in([:source, :fields], &(&1 ++ [:tenant_id]))
+    |> put_in([:source, :columns, :tenant_id], %{type: :integer})
+    |> Map.merge(%{
+      name: :billing,
+      domain_version: "1.0.0",
+      domain_fingerprint: "sha256:provider",
+      published_views: %{
+        invoice_summary_v1: %{
+          version: "1.0.0",
+          compatibility: "~> 1.0",
+          stable: true,
+          database_name: "reporting.invoice_summary",
+          kind: :view,
+          query: fn selecto -> selecto end,
+          columns: %{
+            invoice_id: %{type: :integer},
+            status: %{type: :string},
+            balance_due: %{type: :decimal}
+          },
+          filters: [:status_picker],
+          required_filters: [:tenant_id],
+          fingerprint: "sha256:surface"
+        }
+      }
+    })
+  end
+
+  defp consumer_domain(state) do
+    base_domain()
+    |> Map.merge(%{
+      name: :registration,
+      domain_dependencies: [
+        %{
+          provider: :billing,
+          contract: :invoice_summary_v1,
+          accepts: if(state.version_valid?, do: "~> 1.0", else: "~> 2.0"),
+          expected_fingerprint:
+            if(state.fingerprint_valid?, do: "sha256:surface", else: "sha256:old"),
+          uses: %{
+            fields: [if(state.field_valid?, do: :invoice_id, else: :missing_field)],
+            filters: [if(state.filter_valid?, do: :status_picker, else: :missing_filter)],
+            query_members: []
+          },
+          satisfies: if(state.scope_satisfied?, do: [:tenant_id], else: [])
+        }
+      ]
+    })
+  end
+
+  defp base_domain do
+    %{
+      source: %{
+        source_table: "orders",
+        primary_key: :id,
+        fields: [:id, :status],
+        columns: %{
+          id: %{type: :integer},
+          status: %{type: :string}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      filters: %{
+        status_picker: %{field: :status, type: :string}
+      },
+      required_filters: [{"status", "open"}]
+    }
+  end
+end

--- a/lib/selecto/verification/query_safety.ex
+++ b/lib/selecto/verification/query_safety.ex
@@ -1,0 +1,164 @@
+defmodule Selecto.Verification.QuerySafety do
+  @moduledoc """
+  Bounded-exhaustive verification of Selecto read-path scope invariants.
+
+  The model enumerates tenant-required and tenant-optional domains, absent,
+  row-scoped, and schema-scoped tenant contexts, explicit scope application,
+  and ordinary user filters. It checks fail-closed validation, preservation of
+  required filters, and SQL parameterization for every state.
+
+  A passing result is a proof over this finite model, not a claim about all
+  possible Selecto programs. See `Selecto.Verification.BoundedModel`.
+  """
+
+  alias Selecto.Verification.BoundedModel
+
+  @contexts [:none, :tenant_id, :prefix]
+
+  @doc """
+  Runs the built-in read-path safety model.
+  """
+  @spec verify() :: BoundedModel.report()
+  def verify do
+    BoundedModel.check("selecto.query_scope.v1", states(), invariants())
+  end
+
+  @doc false
+  def states do
+    for tenant_required? <- [false, true],
+        context <- @contexts,
+        apply_scope? <- [false, true],
+        user_filter? <- [false, true] do
+      build_state(tenant_required?, context, apply_scope?, user_filter?)
+    end
+  end
+
+  defp invariants do
+    [
+      {"required_scope_fails_closed", &required_scope_fails_closed/1},
+      {"required_filters_are_preserved", &required_filters_are_preserved/1},
+      {"row_scope_is_parameterized", &row_scope_is_parameterized/1},
+      {"user_filters_cannot_replace_required_scope",
+       &user_filters_cannot_replace_required_scope/1}
+    ]
+  end
+
+  defp build_state(tenant_required?, context, apply_scope?, user_filter?) do
+    query =
+      tenant_required?
+      |> domain()
+      |> Selecto.configure([hostname: "verification.invalid"], validate: false)
+      |> Selecto.select(["name"])
+      |> attach_context(context, tenant_required?)
+      |> maybe_apply_scope(apply_scope?)
+      |> maybe_add_user_filter(user_filter?)
+
+    %{
+      tenant_required?: tenant_required?,
+      context: context,
+      apply_scope?: apply_scope?,
+      user_filter?: user_filter?,
+      query: query
+    }
+  end
+
+  defp required_scope_fails_closed(state) do
+    expected_valid? = expected_valid?(state)
+    actual_valid? = Selecto.validate_tenant_scope(state.query) == :ok
+
+    if actual_valid? == expected_valid?,
+      do: :ok,
+      else: {:error, %{expected_valid?: expected_valid?, actual_valid?: actual_valid?}}
+  end
+
+  defp required_filters_are_preserved(state) do
+    if expected_valid?(state) do
+      required = Selecto.required_filters(state.query)
+      actual = Selecto.query_filters(state.query)
+      missing = required -- actual
+
+      if missing == [], do: :ok, else: {:error, %{missing_filters: missing}}
+    else
+      :ok
+    end
+  end
+
+  defp row_scope_is_parameterized(%{context: :tenant_id, apply_scope?: true} = state) do
+    {sql, params} = Selecto.to_sql(state.query)
+
+    cond do
+      not String.contains?(String.downcase(sql), "tenant_id") ->
+        {:error, :tenant_field_missing_from_sql}
+
+      "tenant-a" not in params ->
+        {:error, %{tenant_value_missing_from_params: params}}
+
+      String.contains?(sql, "tenant-a") ->
+        {:error, :tenant_value_interpolated_into_sql}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp row_scope_is_parameterized(_state), do: :ok
+
+  defp user_filters_cannot_replace_required_scope(
+         %{
+           tenant_required?: true,
+           context: :none,
+           user_filter?: true
+         } = state
+       ) do
+    case Selecto.validate_tenant_scope(state.query) do
+      {:error, %Selecto.Error{}} -> :ok
+      other -> {:error, %{ordinary_filter_satisfied_tenant_scope: other}}
+    end
+  end
+
+  defp user_filters_cannot_replace_required_scope(_state), do: :ok
+
+  defp expected_valid?(%{tenant_required?: false}), do: true
+  defp expected_valid?(%{context: :prefix}), do: true
+  defp expected_valid?(%{context: :tenant_id, apply_scope?: true}), do: true
+  defp expected_valid?(_state), do: false
+
+  defp attach_context(query, :none, _tenant_required?), do: query
+
+  defp attach_context(query, :tenant_id, tenant_required?) do
+    Selecto.with_tenant(query, %{tenant_id: "tenant-a", required: tenant_required?})
+  end
+
+  defp attach_context(query, :prefix, tenant_required?) do
+    Selecto.with_tenant(query, %{prefix: "tenant_a", required: tenant_required?})
+  end
+
+  defp maybe_apply_scope(query, true), do: Selecto.apply_tenant_scope(query)
+  defp maybe_apply_scope(query, false), do: query
+
+  defp maybe_add_user_filter(query, true), do: Selecto.filter(query, {"name", "Ada"})
+  defp maybe_add_user_filter(query, false), do: query
+
+  defp domain(tenant_required?) do
+    %{
+      name: "Verification Accounts",
+      tenant_required: tenant_required?,
+      source: %{
+        source_table: "accounts",
+        primary_key: :id,
+        fields: [:id, :name, :active, :tenant_id],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer},
+          name: %{type: :string},
+          active: %{type: :boolean},
+          tenant_id: %{type: :string}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      required_filters: [{"active", true}]
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Selecto.MixProject do
   def project do
     [
       app: :selecto,
-      version: "0.4.7",
+      version: "0.4.8",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -34,6 +34,7 @@ defmodule Selecto.MixProject do
         extras: [
           "README.md",
           "docs/domain_schema_v1.md",
+          "docs/formal_verification.md",
           "guides/complex_join_patterns.md",
           "guides/olap_and_hierarchical_patterns.md",
           "guides/advanced_usage.md"
@@ -139,6 +140,7 @@ defmodule Selecto.MixProject do
         "LICENSE",
         "CHANGELOG.md",
         "docs/domain_schema_v1.md",
+        "docs/formal_verification.md",
         "guides",
         ".formatter.exs"
       ],

--- a/test/selecto_tenant_test.exs
+++ b/test/selecto_tenant_test.exs
@@ -108,6 +108,21 @@ defmodule Selecto.TenantTest do
              Selecto.validate_tenant_scope(query)
   end
 
+  test "tenant context id does not satisfy required scope until it becomes a filter" do
+    query =
+      tenant_required_domain()
+      |> selecto()
+      |> Selecto.with_tenant(%{tenant_id: "acme", required: true})
+
+    assert {:error, %Selecto.Error{type: :validation_error}} =
+             Selecto.validate_tenant_scope(query)
+
+    assert :ok =
+             query
+             |> Selecto.apply_tenant_scope()
+             |> Selecto.validate_tenant_scope()
+  end
+
   test "query_filters raises when tenant is required and missing" do
     query =
       tenant_required_domain()

--- a/test/selecto_verification_bounded_model_test.exs
+++ b/test/selecto_verification_bounded_model_test.exs
@@ -1,0 +1,61 @@
+defmodule Selecto.Verification.BoundedModelTest do
+  use ExUnit.Case, async: true
+
+  alias Selecto.Verification.BoundedModel
+
+  test "proves every invariant across the complete supplied model" do
+    report =
+      BoundedModel.check("booleans", [false, true], [
+        {"is_boolean", fn state -> is_boolean(state) end},
+        {"double_negation", fn state -> not not state == state end}
+      ])
+
+    assert report.proof_level == :bounded_exhaustive
+    assert report.state_count == 2
+    assert report.invariant_count == 2
+    assert report.check_count == 4
+    assert report.proved?
+    assert report.counterexamples == []
+  end
+
+  test "returns deterministic, reproducible counterexamples" do
+    report =
+      BoundedModel.check("small integers", 0..2, [
+        {"less_than_two", fn state -> state < 2 end}
+      ])
+
+    refute report.proved?
+
+    assert report.counterexamples == [
+             %{
+               invariant: "less_than_two",
+               invariant_index: 0,
+               state_index: 2,
+               state: 2,
+               reason: :returned_false
+             }
+           ]
+  end
+
+  test "captures invariant exceptions instead of aborting the proof run" do
+    report =
+      BoundedModel.check("exceptions", [:bad], [
+        {"safe", fn _ -> raise "boom" end}
+      ])
+
+    assert [
+             %{
+               reason: %{tuple: [:exception, RuntimeError, "boom"]}
+             }
+           ] = report.counterexamples
+  end
+
+  test "counterexamples remain JSON serializable for artifact output" do
+    report =
+      BoundedModel.check("portable", [%{tuple: {:tenant_id, 7}, callback: fn -> :ok end}], [
+        {"fails", fn _ -> false end}
+      ])
+
+    assert {:ok, _json} = Jason.encode(report)
+  end
+end

--- a/test/selecto_verification_contract_safety_test.exs
+++ b/test/selecto_verification_contract_safety_test.exs
@@ -1,0 +1,14 @@
+defmodule Selecto.Verification.ContractSafetyTest do
+  use ExUnit.Case, async: true
+
+  alias Selecto.Verification.ContractSafety
+
+  test "proves the provider-consumer compatibility matrix" do
+    report = ContractSafety.verify()
+
+    assert report.state_count == 32
+    assert report.invariant_count == 2
+    assert report.check_count == 64
+    assert report.proved?, inspect(report.counterexamples, pretty: true)
+  end
+end

--- a/test/selecto_verification_query_safety_test.exs
+++ b/test/selecto_verification_query_safety_test.exs
@@ -1,0 +1,15 @@
+defmodule Selecto.Verification.QuerySafetyTest do
+  use ExUnit.Case, async: true
+
+  alias Selecto.Verification.QuerySafety
+
+  test "proves the complete built-in query scope model" do
+    report = QuerySafety.verify()
+
+    assert report.proof_level == :bounded_exhaustive
+    assert report.state_count == 24
+    assert report.invariant_count == 4
+    assert report.check_count == 96
+    assert report.proved?, inspect(report.counterexamples, pretty: true)
+  end
+end


### PR DESCRIPTION
## What changed

- add a reusable bounded-exhaustive model checker
- verify query tenant scope and provider/consumer contract compatibility
- fix the fail-open tenant validation path found by the model
- add JSON proof artifacts and `mix selecto.verify`
- document the proof boundary
- bump Selecto to 0.4.8 and add a versioned changelog entry

## Why

Selecto needs reproducible, explicit confidence that required scope survives query construction and that consumers remain compatible with published domain contracts.

## Validation

- `mise exec -- mix test` — 1,173 passed, including 3 properties; 10 excluded
- `mise exec -- mix selecto.verify` — 160 bounded-exhaustive checks proved
- compile with warnings as errors
- format check
- `mix hex.build` for Selecto 0.4.8
- `git diff --check`